### PR TITLE
small bug on image croping function

### DIFF
--- a/code/face_landmark_detection.py
+++ b/code/face_landmark_detection.py
@@ -67,7 +67,7 @@ def crop_image_help(img1,img2):
         return [img1[diff0:avg0,:],img2[:,-diff1:avg1]]
 
     else:
-        return [img1[:,diff1:avg1],img2[-diff0:avg0,:]]
+        return [img1[:,diff1:avg1],img2[diff0:avg0,:]]
 
 def generate_face_correspondences(theImage1, theImage2):
     # Detect the points of face.


### PR DESCRIPTION
img1 shape : (1009, 1108, 3)
img2 shape:  (1024, 1024, 3)
diff1,avg1,diff0,avg0 = 42, 1066, 7 ,1016
after cropped the images, shapes are : (1009, 1024, 3) (0, 1024, 3)
which gives error as second image shape is not perfect.
So I've fixed in **face_landmark_detection.py file on line 70.**

please merge this request!

