### PR TITLE
Additional requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ opencv_python
 Pillow
 skimage
 imutils
+face_utils
 cmake
 dlib
 ```

--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@ scikit_image
 opencv_python
 Pillow
 skimage
+imutils
+cmake
 dlib
 ```
 


### PR DESCRIPTION
While downloading the dependencies required I noticed that `dlib` required `cmake` to be able to install so that should probably be on this list to and while running __init__.py it requested the module `imutils` which wasn't on the list either.